### PR TITLE
Fix GitHub streak stats image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Design and deploy practical AI systems (LLMs + Computer Vision) with a strong em
 ## 📈 GitHub Snapshot
 <p align="center">
   <img src="https://github-readme-stats.vercel.app/api?username=cybki&show_icons=true&theme=transparent&hide_border=true&rank_icon=github" alt="GitHub Stats" />
-  <img src="https://streak-stats.demolab.com?user=cybki&theme=transparent&hide_border=true" alt="GitHub Streak" />
+  <img src="https://streak-stats.demolab.com/?user=cybki&theme=transparent&hide_border=true" alt="GitHub Streak" />
 </p>
 <p align="center">
   <img src="https://github-readme-activity-graph.vercel.app/graph?username=cybki&theme=github-compact&hide_border=true&area=true" alt="Activity Graph" />


### PR DESCRIPTION
## Summary
- ensure the GitHub streak card URL uses the correct endpoint so the badge renders properly

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cc25157bf08332912c9efc385c6e85